### PR TITLE
feat(ui): remove crc risk score box and add ai risk score display for cases

### DIFF
--- a/src/pages/Case/index.tsx
+++ b/src/pages/Case/index.tsx
@@ -39,7 +39,7 @@ const NestedContent = ({ data, level, important = false }: { data: TreeNode; lev
   return (
     <>
       {(data.values as TreeNode[]).map((item, index) => {
-        return <NestedSection data={item} key={index} level={level + 1} important={important}></NestedSection>;
+        return <NestedSection data={item} key={index} level={level + 1} important={important} />;
       })}
     </>
   );
@@ -113,7 +113,11 @@ const Card = ({ data, index }: { data: TreeNode; index: number }) => {
       data-testid={data.key}
       className={classnames(styles.card, { [styles.highlightContent]: highlight }, { [styles.firstCard]: index === 0 })}
     >
-      <div className={classnames(styles.subTitle, { [styles.subTitleHighlight]: highlight })}>
+      <div
+        className={classnames(styles.subTitle, {
+          [styles.subTitleHighlight]: highlight,
+        })}
+      >
         {data.key}
         {data.style?.collapse && (
           <IconButton onClick={() => setOpen(!open)} aria-label="expand" size="small">
@@ -135,9 +139,11 @@ const Section = ({ data, index }: { data: TreeNode; index: number }) => {
   return (
     <div style={style} className={styles.container} data-testid={data.key}>
       <div className={`${styles.title}`}>{data.key}</div>
-      {(data.values as TreeNode[]).map((item, index) => (
-        <Card data={item} key={index} index={index}></Card>
-      ))}
+      {(data.values as TreeNode[])
+        .filter((item) => item.key !== "CRC risk assessments")
+        .map((item, idx) => (
+          <Card data={item} key={idx} index={idx} />
+        ))}
     </div>
   );
 };
@@ -166,6 +172,7 @@ const CasePage = () => {
   const { loading, data } = useRequest(() => getCaseDetail(caseConfigId));
   const response = data?.data;
   const [caseState, setCaseState] = useAtom(caseAtom);
+
   useEffect(() => {
     setCaseState({
       caseNumber: response?.data.caseNumber,
@@ -185,8 +192,8 @@ const CasePage = () => {
             {response.data.importantInfos && response.data.importantInfos.length > 0 && (
               <ImportantCard data={response.data.importantInfos} />
             )}
-            {(response.data.details as TreeNode[]).map((item, index) => (
-              <Section data={item} key={index} index={index}></Section>
+            {(response.data.details as TreeNode[]).map((item, idx) => (
+              <Section data={item} key={idx} index={idx} />
             ))}
             <div className={styles.submitDiv}>
               <Button


### PR DESCRIPTION
## PR #6 - `remove crc risk score box and add ai risk score display for cases`

Per Sophia and the lab leaders' request, this PR attempts to remove the `CRC Risk Assessment` box at the bottom from the UI and shows the `AI Risk Score` box at the top of the page, under the `Important Info` section. This is done in order to achieve the randomization logic in showing AI risk score (where only a subset of cases are shown with the AI risk score - not all). 

This is how the UI now looks like:

<img width="1512" alt="Screenshot 2025-06-02 at 20 20 20" src="https://github.com/user-attachments/assets/61bed72c-cdea-4cfb-a6a4-2ce792dc1c53" />
