### PR TITLE
feat(ui-api): collect user answer metrics and persist them

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## SUMMARY
+
+## TEST PLAN
+
+---
+
+## Pre-merge author checklist
+
+- [ ] I've clearly explained:
+  - [ ] What problem this PR is solving.
+  - [ ] How this problem was solved.
+  - [ ] How reviewers can test my changes.
+- [ ] I've indicated what Jira issue(s) this PR is linked to.
+- [ ] I've included tests I've run to ensure my changes work.
+- [ ] I've added unit tests for any new code, if applicable.
+- [ ] I've documented any added code.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,61 @@
+# Security
+
+This document summarizes the key security controls and best practices for the AugMed App (frontend + backend).
+
+## 1. Transport Security
+- **HTTPS only**  
+  All traffic to `https://augmed1.dhep.org` is encrypted with TLS.  
+- **HSTS**  
+  The backend API enforces HTTP Strict Transport Security to prevent downgrade attacks.
+
+## 2. Authentication & Authorization
+- **JWT-based auth**  
+  Users authenticate via a JSON Web Token (JWT) issued by the backend.  
+- **httpOnly cookies**  
+  JWTs are stored in httpOnly cookies to mitigate XSS-based token theft.  
+- **Route protection**  
+  All API endpoints under `/api/*` require a valid JWT and check user ownership.
+
+## 3. CORS
+- **Restricted origin**  
+  Backend CORS policy only allows requests from the official frontend origin (`https://augmed1.dhep.org`).  
+- **Preflight checks**  
+  `OPTIONS` requests are handled and validated before allowing any state-changing method.
+
+## 4. Secrets & Config
+- **Environment variables**  
+  All secrets (database URLs, JWT signing keys, third-party API keys) are injected via environment variables—never checked into source control.  
+- **.env exclusions**  
+  The repository’s `.gitignore` excludes any local `.env` or secret files.
+
+## 5. Dependency Management
+- **Regular audits**  
+  - Frontend: `npm audit` (or `yarn audit`) run on each CI build.  
+  - Backend: `pip-audit` (or `safety`) scans Python dependencies for known vulnerabilities.  
+- **Pinned versions**  
+  `package.json` and `requirements.txt` use exact version pins to ensure reproducible installs.
+
+## 6. Input Validation & Output Encoding
+- **Schema validation**  
+  Backend request bodies are validated against JSON schemas via `flask_json_schema`.  
+- **ORM usage**  
+  All database access uses SQLAlchemy with parameterized queries to prevent SQL injection.  
+- **Escape output**  
+  Frontend templates escape any user-provided content to avoid XSS.
+
+## 7. Content Security Policy (CSP)
+- The frontend sets a strict CSP header to disallow inline scripts and only allow trusted script sources.
+
+## 8. Logging & Monitoring
+- **Audit logs**  
+  Security-related events (login, token validation failures, analytics submissions) are logged centrally.  
+- **Error handling**  
+  Stack traces and internal errors are never exposed to end users; they are captured in server logs only.
+
+## 9. Database Migrations
+- **Alembic migrations**  
+  Schema changes are tracked and applied via Alembic; no manual DDL in production.
+
+---
+
+> For any security concerns, please contact the DHEP Lab’s security team at `dhep.lab@gmail.com`.  

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ AugMed is a web application, built for the UNC-Chapel Hill DHEP Lab, that allows
 ![AWS ECR](https://img.shields.io/badge/AWS%20ECR-F58534?style=for-the-badge&logo=aws&logoColor=white)
 ![AWS ECS](https://img.shields.io/badge/AWS%20ECS-FF5A00?style=for-the-badge&logo=aws&logoColor=white)
 ![AWS ALB](https://img.shields.io/badge/AWS%20ALB-232F3E?style=for-the-badge&logo=amazon-aws&logoColor=white)
+![Terraform](https://img.shields.io/badge/Terraform-7B42BC?style=for-the-badge&logo=terraform&logoColor=white)
 
 # Getting Started with the AugMed App
 
@@ -100,6 +101,22 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+## Deployment
+
+The app is deployed using AWS services. The deployment process involves the following steps:
+
+1. **Build the app**: Run `npm run build` to create a production build of the app. This is automatically done in the CI/CD pipeline (GitHub Actions).
+2. **Push the build to AWS S3**: The build files are uploaded to an S3 bucket for hosting.
+3. **Deploy the app using AWS ECS**: The app is deployed to an ECS cluster using a Docker container.
+4. **Configure the load balancer**: An Application Load Balancer (ALB) is set up to route traffic to the ECS service.
+5. **Set up DNS**: The domain name is configured to point to the ALB.
+6. **Monitor the deployment**: The deployment is monitored to ensure that the app is running smoothly.
+7. **Update the app**: When updates are made to the app, the deployment process is repeated to push the changes to production.
+
+It also uses Terraform to manage the infrastructure as code.
+
+> **Visit the [augmed-infra repository](https://github.com/DHEPLab/augmed-infra) for more details on the infrastructure setup and deployment process.**
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ AugMed is a web application, built for the UNC-Chapel Hill DHEP Lab, that allows
 ![Jest](https://img.shields.io/badge/Jest-C21325?style=for-the-badge&logo=jest&logoColor=white)
 ![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
 ![GitHub](https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white)
-
+![AWS RDS](https://img.shields.io/badge/AWS%20RDS-527FFF?style=for-the-badge&logo=amazon-rds&logoColor=white)
+![AWS S3](https://img.shields.io/badge/AWS%20S3-8C4FFF?style=for-the-badge&logo=amazon-s3&logoColor=white)
+![AWS ECR](https://img.shields.io/badge/AWS%20ECR-F58534?style=for-the-badge&logo=aws&logoColor=white)
+![AWS ECS](https://img.shields.io/badge/AWS%20ECS-FF5A00?style=for-the-badge&logo=aws&logoColor=white)
+![AWS ALB](https://img.shields.io/badge/AWS%20ALB-232F3E?style=for-the-badge&logo=amazon-aws&logoColor=white)
 
 # Getting Started with the AugMed App
 

--- a/src/services/answerService.ts
+++ b/src/services/answerService.ts
@@ -1,18 +1,47 @@
 import { request } from "./api";
 import { AnswerPageConfigResponse } from "../types/answer";
 import { AnswerFormData } from "../state";
+import { getCaseOpenTime } from "./caseService";
+import { postAnalytics, AnalyticsPayload } from "./metricsService";
 
-export const saveAnswer = async (caseConfigId: string, answerFormData: AnswerFormData, answerConfigId: string) => {
-  return await request(`/answer/${caseConfigId}`, {
+let _answerOpenTime: string | null = null;
+
+export const getAnswerPageConfig = async () => {
+  // mark answer‐open time once
+  if (!_answerOpenTime) {
+    _answerOpenTime = new Date().toISOString();
+  }
+  return await request<{ data: AnswerPageConfigResponse }>(
+    `/config/answer`,
+    { method: "GET" }
+  );
+};
+
+export const saveAnswer = async (
+  caseConfigId: string,
+  answerFormData: AnswerFormData,
+  answerConfigId: string
+) => {
+  // record submit time
+  const submitTime = new Date().toISOString();
+
+  // first save the answer
+  const res = await request(`/answer/${caseConfigId}`, {
     method: "POST",
     data: {
       answer: answerFormData,
-      answerConfigId: answerConfigId,
+      answerConfigId,
     },
   });
-};
-export const getAnswerPageConfig = async () => {
-  return await request<{ data: AnswerPageConfigResponse }>(`/config/answer `, {
-    method: "GET",
-  });
+
+  // then ship the analytics payload
+  const payload: AnalyticsPayload = {
+    caseConfigId,
+    caseOpenTime:    getCaseOpenTime(),
+    answerOpenTime:  _answerOpenTime!,
+    answerSubmitTime:submitTime,
+  };
+  await postAnalytics(payload);
+
+  return res;
 };

--- a/src/services/caseService.ts
+++ b/src/services/caseService.ts
@@ -1,6 +1,8 @@
 import { request } from "./api";
 import { CaseDetail, ICase } from "../types/case";
 
+let _caseOpenTime: string | null = null;
+
 export const getCaseList = async () => {
   return await request<{ data: ICase[] }>(`/cases`, {
     method: "GET",
@@ -8,7 +10,17 @@ export const getCaseList = async () => {
 };
 
 export const getCaseDetail = async (caseConfigId: string) => {
-  return await request<{ data: CaseDetail }>(`/case-reviews/${caseConfigId}`, {
-    method: "GET",
-  });
+  // mark case‐open time once, on first fetch
+  if (!_caseOpenTime) {
+    _caseOpenTime = new Date().toISOString();
+  }
+  return await request<{ data: CaseDetail }>(
+    `/case-reviews/${caseConfigId}`,
+    { method: "GET" }
+  );
+};
+
+/** expose for metrics */
+export const getCaseOpenTime = (): string => {
+  return _caseOpenTime!;
 };

--- a/src/services/metricsService.ts
+++ b/src/services/metricsService.ts
@@ -1,0 +1,24 @@
+import { request } from "./api";
+
+export interface AnalyticsPayload {
+  caseConfigId:    string;
+  caseOpenTime:    string;  // ISO8601
+  answerOpenTime:  string;  // ISO8601
+  answerSubmitTime:string;  // ISO8601
+}
+
+/**
+ * App now collects the user’s interaction timings—
+ *  - when they opened the case review,
+ *  - when they navigated to the answer page,
+ *  - and when they submitted their answers—
+ * and sends these metrics to the backend analytics endpoint.
+ *
+ * @param payload AnalyticsPayload containing the caseConfigId and ISO-8601 timestamps
+ */
+export const postAnalytics = async (payload: AnalyticsPayload) => {
+  return await request("/analytics", {
+    method: "POST",
+    data: payload,
+  });
+};


### PR DESCRIPTION
App now collects the user’s interaction timings: when they opened the case review, when they navigated to the answer page, and when they submitted their answers—and sends these metrics to the backend analytics endpoint.

This involves creating a new analytics table in our Postgres database. Developers and researchers can view/export data in this table for more analysis of the users' data.