### PR TITLE
feat(ui): fix score bounds

### DIFF
--- a/src/pages/Case/index.tsx
+++ b/src/pages/Case/index.tsx
@@ -109,7 +109,7 @@ const NestedContent = ({
             if (!isNaN(rawNum)) {
               if (rawNum < 6) {
                 label = "Low";
-              } else if (rawNum <= 11) {
+              } else if (rawNum < 14) {
                 label = "Medium";
               } else {
                 label = "High";
@@ -295,7 +295,7 @@ const ImportantCard = ({ data }: { data: TreeNode[] }) => {
                     {display} {label && `(${label})`}
                   </div>
                   <div className={styles.crcThresholdLine}>
-                    <em>0-6: Low; 6-11: Med; 11-14: High</em>
+                    <em>0-6: Low; 6-14: Med; 14-18: High</em>
                   </div>
                 </div>
               );


### PR DESCRIPTION
## SUMMARY

Fix score bounds so that the "high" range is from 14 to 18 and "med" is < 14.

## TEST PLAN

Go to the frontend/run it and verify that on cases where AI score is displayed, the high range is now 14-18 and the medium range is from 6-14.

---

## Pre-merge author checklist

- [X] I've clearly explained:
  - [X] What problem this PR is solving.
  - [X] How this problem was solved.
  - [X] How reviewers can test my changes.
- [X] I've included tests I've run to ensure my changes work.
- [ ] I've added unit tests for any new code, if applicable.
- [X] I've documented any added code.
